### PR TITLE
[#22] n+1 문제 해결

### DIFF
--- a/src/main/kotlin/com/seokjoo/todo/domain/repository/todo/TodoRepository.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/repository/todo/TodoRepository.kt
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface TodoRepository : JpaRepository<Todo, Long> {
 
-    @Query("select t from Todo t left join fetch t.todoCategories")
+    @Query("select t from Todo t left join fetch t.todoCategories tc left join fetch tc.category")
     fun findAllWithCategories(): List<Todo>
 }

--- a/src/main/kotlin/com/seokjoo/todo/domain/repository/todo/TodoRepository.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/repository/todo/TodoRepository.kt
@@ -2,7 +2,12 @@ package com.seokjoo.todo.domain.repository.todo
 
 import com.seokjoo.todo.domain.entity.todo.Todo
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface TodoRepository : JpaRepository<Todo, Long>
+interface TodoRepository : JpaRepository<Todo, Long> {
+
+    @Query("select t from Todo t left join fetch t.todoCategories")
+    fun findAllWithCategories(): List<Todo>
+}

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
@@ -19,7 +19,7 @@ class TodoService(
     private val todoCategoryRepository: TodoCategoryRepository,
 ) {
     fun getAllTodos(): List<TodoServiceResponseDTO> {
-        val todoList = todoRepository.findAll()
+        val todoList = todoRepository.findAllWithCategories()
         return todoList.map { todo -> TodoServiceResponseDTO.from(todo) }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,5 +13,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    properties:
+      hibernate.format_sql: true
     database: postgresql
     database-platform: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
페이징에서 left join fetch로 n+1 문제가 해결이 안된다고 어디선가 들었습니다.. 그 이전에 마주한 n+1 먼저 해결하고, 페이징에서 또한번 고민해보겠습니다.

살짝 공부해보니, n+1 문제는 Lazy Loading 과정에서 발생하기 때문에, 반드시 발생하는건 아니라고 하더군요 , , , , 해당 프로퍼티를 사용 안하면 괜찮지만, 저는 todoCategories 를 통해서 카테고리까지 모두 가져와서 n+1이 발생했던 것 같아용
이건 확실하지 않은데, map 을 통해 DTO를 만드는 과정에서 부른 것 때문이 맞을까요 ? ( 요곤 수정된 부분이 없어서 여기 썼습니다 ,,, 죄송...)

```
    fun getAllTodos(): List<TodoServiceResponseDTO> {
        val todoList = todoRepository.findAllWithCategories()
        return todoList.map { todo -> TodoServiceResponseDTO.from(todo) }
    }
...
    companion object {
        fun from(todo: Todo) = TodoServiceResponseDTO(
            id = todo.id,
            todo = todo.todo,
            isDone = todo.isDone,
            categories = todo.todoCategories.map { it.category?.name.orEmpty() },
        )
    }

```

이슈 #22 에서 n+1 문제가 발생하는걸 확인 했고, 아래와 같이 해결된 것도 확인했습니다.

아래 사진에서 아마 3번 쿼리가 더 불린 이유는, 제가 테스트 데이터로 category를 [darama, comedy, horror] 3개를 넣어서 매칭되는 카테고리 3개를 부르느라 3번이 더불렸을 것 같아용 
![image](https://github.com/user-attachments/assets/d37536af-6c99-40e8-b949-60e151567584)

지피티랑 협업해서,, 한단계 더 줄여봤습니다 
![image](https://github.com/user-attachments/assets/44853766-c7de-4290-b845-2b4e9a7b0496)

close #22 
