### PR TITLE
[#17] 응답에 캐싱 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,6 @@ on:
     branches: [ "develop" ]
 
 jobs:
-  redis-container:
-    runs-on: ubuntu-latest
-    container: redis
-    env:
-      # 테스트용 임의로 생성한 값입니다 (실제 값 아님!)
-      REDIS_HOST: localhost
-      REDIS_PORT: 6380
-
   build:
     runs-on: ubuntu-latest
     needs: redis-container
@@ -32,6 +24,11 @@ jobs:
       JWT_SECRETS: zKiWKx6Cv9wDMeVE63GgbWPRDIpLEhpJb67_DRPqeAE
       JWT_ACCESS_TOKEN_EXPIRED_TIME: 1000000
       JWT_REFRESH_TOKEN_EXPIRED_TIME: 10000000
+    services:
+      redis:
+        image: redis
+        ports:
+          - '6380:6379'
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +45,9 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: 6380
 
   ## 처음보는데, 의존성 그래프를 만들어서 보안 취약점에 대한 경고를 준다네요
   dependency-submission:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,17 @@ on:
     branches: [ "develop" ]
 
 jobs:
+  redis-container:
+    runs-on: ubuntu-latest
+    container: redis
+    env:
+      # 테스트용 임의로 생성한 값입니다 (실제 값 아님!)
+      REDIS_HOST: localhost
+      REDIS_PORT: 6380
+
   build:
     runs-on: ubuntu-latest
+    needs: redis-container
     permissions:
       contents: read
     env:
@@ -23,7 +32,6 @@ jobs:
       JWT_SECRETS: zKiWKx6Cv9wDMeVE63GgbWPRDIpLEhpJb67_DRPqeAE
       JWT_ACCESS_TOKEN_EXPIRED_TIME: 1000000
       JWT_REFRESH_TOKEN_EXPIRED_TIME: 10000000
-      REDIS_PASSWORD: 1234
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       JWT_SECRETS: zKiWKx6Cv9wDMeVE63GgbWPRDIpLEhpJb67_DRPqeAE
       JWT_ACCESS_TOKEN_EXPIRED_TIME: 1000000
       JWT_REFRESH_TOKEN_EXPIRED_TIME: 10000000
+      REDIS_PASSWORD: 1234
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    needs: redis-container
     permissions:
       contents: read
     env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
     implementation("org.springframework.security:spring-security-crypto:6.4.4")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,8 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
-    implementation("org.springframework.security:spring-security-crypto:6.1.2")
+    implementation("org.springframework.security:spring-security-crypto:6.4.4")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ x-environment: &common_environment
   - MYSQL_REPLICATION_PASSWORD: $MYSQL_REPLICATION_PASSWORD
 
 services:
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - '6379:6379'
+
   mysql-master:
     image: bitnami/mysql
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
     container_name: redis
     ports:
       - '6379:6379'
+  test-redis:
+    image: redis
+    container_name: test-redis
+    ports:
+      - '6380:6379'
 
   mysql-master:
     image: bitnami/mysql

--- a/src/main/kotlin/com/seokjoo/todo/TodoApplication.kt
+++ b/src/main/kotlin/com/seokjoo/todo/TodoApplication.kt
@@ -2,8 +2,10 @@ package com.seokjoo.todo
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
 
 @SpringBootApplication
+@EnableCaching
 class TodoApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoPageServiceResponseDTO.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoPageServiceResponseDTO.kt
@@ -1,6 +1,9 @@
 package com.seokjoo.todo.domain.service.todo
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 data class TodoPageServiceResponseDTO(
-    val isLast: Boolean,
-    val responseList: List<TodoServiceResponseDTO>,
+    val isLast: Boolean = false,
+    val responseList: List<TodoServiceResponseDTO> = emptyList(),
 )

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoPageServiceResponseDTO.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoPageServiceResponseDTO.kt
@@ -1,6 +1,6 @@
 package com.seokjoo.todo.domain.service.todo
 
 data class TodoPageServiceResponseDTO(
-    val isLast: Boolean = true,
-    val responseList: List<TodoServiceResponseDTO> = emptyList(),
+    val isLast: Boolean,
+    val responseList: List<TodoServiceResponseDTO>,
 )

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoPageServiceResponseDTO.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoPageServiceResponseDTO.kt
@@ -1,6 +1,6 @@
 package com.seokjoo.todo.domain.service.todo
 
 data class TodoPageServiceResponseDTO(
-    val isLast: Boolean,
-    val responseList: List<TodoServiceResponseDTO>,
+    val isLast: Boolean = true,
+    val responseList: List<TodoServiceResponseDTO> = emptyList(),
 )

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
@@ -7,6 +7,8 @@ import com.seokjoo.todo.domain.entity.todo.Todo
 import com.seokjoo.todo.domain.repository.category.CategoryRepository
 import com.seokjoo.todo.domain.repository.todo.TodoRepository
 import com.seokjoo.todo.domain.service.remove.TodoDeleteService
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
@@ -20,6 +22,7 @@ class TodoService(
     private val categoryRepository: CategoryRepository,
     private val todoDeleteService: TodoDeleteService,
 ) {
+    @Cacheable(cacheNames = ["todos"], key = "'todos'")
     fun getPagedTodos(pageServiceDTO: TodoPageServiceDTO): TodoPageServiceResponseDTO {
         val pageRequest =
             PageRequest.of(pageServiceDTO.pageNumber, pageServiceDTO.pageSize, Sort.by("updatedAt").ascending())
@@ -30,12 +33,14 @@ class TodoService(
         return TodoPageServiceResponseDTO(isLast = todoPage.isLast, responseList = todoPagedList)
     }
 
+    @Cacheable(cacheNames = ["todos"], key = "todos")
     fun getTodoById(id: Long): TodoServiceResponseDTO {
         val result = todoRepository.findByIdOrNull(id) ?: throw TodoException.of(TodoExceptionType.NOT_EXISTED_TODO)
         return TodoServiceResponseDTO.from(result)
     }
 
     @Transactional
+    @CacheEvict(value = ["todos"])
     fun createTodo(request: TodoServiceRequestDTO): TodoServiceResponseDTO {
         // 1. 저장하여 영속화 먼저
         val todo = Todo(todo = request.todo, isDone = request.isDone)
@@ -46,6 +51,7 @@ class TodoService(
     }
 
     @Transactional
+    @CacheEvict(value = ["todos"])
     fun updateTodo(id: Long, request: TodoServiceRequestDTO): TodoServiceResponseDTO {
         val todo = todoRepository.findByIdOrNull(id) ?: throw TodoException.of(TodoExceptionType.NOT_EXISTED_TODO)
 
@@ -61,6 +67,7 @@ class TodoService(
     }
 
     @Transactional
+    @CacheEvict(value = ["todos"])
     fun deleteTodo(id: Long) {
         val todo = todoRepository.findByIdOrNull(id) ?: throw TodoException.of(TodoExceptionType.NOT_EXISTED_TODO)
 

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
@@ -27,6 +27,7 @@ class TodoService(
     // 현재 캐시매니저가 1개라서 안써도 되지만 공부용으로 명시함
     @Cacheable(
         cacheNames = ["todos"],
+        unless = "#result.responseList.isEmpty()",
         key = "'todos:page:' + #pageServiceDTO.pageNumber + ':size:' + #pageServiceDTO.pageSize",
         cacheManager = "todoCacheManager"
     )

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
@@ -8,7 +8,9 @@ import com.seokjoo.todo.domain.repository.category.CategoryRepository
 import com.seokjoo.todo.domain.repository.todo.TodoRepository
 import com.seokjoo.todo.domain.service.remove.TodoDeleteService
 import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.annotation.Caching
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
@@ -52,6 +54,7 @@ class TodoService(
 
     @Transactional
     @CacheEvict(value = ["todos"])
+    @CachePut(cacheNames = ["todo"], key = "#id")
     fun updateTodo(id: Long, request: TodoServiceRequestDTO): TodoServiceResponseDTO {
         val todo = todoRepository.findByIdOrNull(id) ?: throw TodoException.of(TodoExceptionType.NOT_EXISTED_TODO)
 
@@ -67,7 +70,12 @@ class TodoService(
     }
 
     @Transactional
-    @CacheEvict(value = ["todos"])
+    @Caching(
+        evict = [
+            CacheEvict(value = ["todos"]),
+            CacheEvict(value = ["todo"], key = "#id"),
+        ]
+    )
     fun deleteTodo(id: Long) {
         val todo = todoRepository.findByIdOrNull(id) ?: throw TodoException.of(TodoExceptionType.NOT_EXISTED_TODO)
 

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
@@ -33,7 +33,7 @@ class TodoService(
         return TodoPageServiceResponseDTO(isLast = todoPage.isLast, responseList = todoPagedList)
     }
 
-    @Cacheable(cacheNames = ["todos"], key = "todos")
+    @Cacheable(cacheNames = ["todo"], key = "#id")
     fun getTodoById(id: Long): TodoServiceResponseDTO {
         val result = todoRepository.findByIdOrNull(id) ?: throw TodoException.of(TodoExceptionType.NOT_EXISTED_TODO)
         return TodoServiceResponseDTO.from(result)

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoService.kt
@@ -24,7 +24,12 @@ class TodoService(
     private val categoryRepository: CategoryRepository,
     private val todoDeleteService: TodoDeleteService,
 ) {
-    @Cacheable(cacheNames = ["todos"], key = "'todos'")
+    // 현재 캐시매니저가 1개라서 안써도 되지만 공부용으로 명시함
+    @Cacheable(
+        cacheNames = ["todos"],
+        key = "'todos:page:' + #pageServiceDTO.pageNumber + ':size:' + #pageServiceDTO.pageSize",
+        cacheManager = "todoCacheManager"
+    )
     fun getPagedTodos(pageServiceDTO: TodoPageServiceDTO): TodoPageServiceResponseDTO {
         val pageRequest =
             PageRequest.of(pageServiceDTO.pageNumber, pageServiceDTO.pageSize, Sort.by("updatedAt").ascending())

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceResponseDTO.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceResponseDTO.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.seokjoo.todo.domain.entity.todo.Todo
 
 data class TodoServiceResponseDTO(
-    val id: Long = 0L,
-    val todo: String = "",
+    val id: Long,
+    val todo: String,
     @JsonProperty("isDone") // is가 붙으면 is를 빼버리고 내부에 저장해버림;;
-    val isDone: Boolean = false,
-    val categories: List<String> = emptyList(),
+    val isDone: Boolean,
+    val categories: List<String>,
 ) {
     companion object {
         fun from(todo: Todo) = TodoServiceResponseDTO(

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceResponseDTO.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceResponseDTO.kt
@@ -1,12 +1,14 @@
 package com.seokjoo.todo.domain.service.todo
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.seokjoo.todo.domain.entity.todo.Todo
 
 data class TodoServiceResponseDTO(
-    val id: Long,
-    val todo: String,
-    val isDone: Boolean,
-    val categories: List<String>,
+    val id: Long = 0L,
+    val todo: String = "",
+    @JsonProperty("isDone") // is가 붙으면 is를 빼버리고 내부에 저장해버림;;
+    val isDone: Boolean = false,
+    val categories: List<String> = emptyList(),
 ) {
     companion object {
         fun from(todo: Todo) = TodoServiceResponseDTO(

--- a/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceResponseDTO.kt
+++ b/src/main/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceResponseDTO.kt
@@ -1,14 +1,16 @@
 package com.seokjoo.todo.domain.service.todo
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.seokjoo.todo.domain.entity.todo.Todo
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 data class TodoServiceResponseDTO(
-    val id: Long,
-    val todo: String,
+    val id: Long = 0L,
+    val todo: String = "",
     @JsonProperty("isDone") // is가 붙으면 is를 빼버리고 내부에 저장해버림;;
-    val isDone: Boolean,
-    val categories: List<String>,
+    val isDone: Boolean = false,
+    val categories: List<String> = emptyList(),
 ) {
     companion object {
         fun from(todo: Todo) = TodoServiceResponseDTO(

--- a/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
+++ b/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
@@ -1,8 +1,10 @@
 package com.seokjoo.todo.presentation.configuration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.seokjoo.todo.common.common.jwt.JwtAuthFilter
 import com.seokjoo.todo.common.common.jwt.JwtProvider
+import com.seokjoo.todo.domain.service.todo.TodoPageServiceResponseDTO
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Bean
@@ -10,7 +12,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -36,14 +38,13 @@ class TodoConfiguration(
 
     @Bean
     fun redisCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+        val objectMapper = jacksonObjectMapper()
+        val serializer = Jackson2JsonRedisSerializer(objectMapper, TodoPageServiceResponseDTO::class.java)
+
         val config = RedisCacheConfiguration.defaultCacheConfig()
             .disableCachingNullValues()
-            .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                    GenericJackson2JsonRedisSerializer()
-                )
-            )
-            .entryTtl(Duration.ofMinutes(1)) // 임의의 1분
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            .entryTtl(Duration.ofMinutes(1))
 
         return RedisCacheManager.builder(connectionFactory)
             .cacheDefaults(config)

--- a/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
+++ b/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
@@ -1,11 +1,13 @@
 package com.seokjoo.todo.presentation.configuration
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.seokjoo.todo.common.common.jwt.JwtAuthFilter
 import com.seokjoo.todo.common.common.jwt.JwtProvider
-import com.seokjoo.todo.domain.service.todo.TodoPageServiceResponseDTO
-import com.seokjoo.todo.domain.service.todo.TodoServiceResponseDTO
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.cache.CacheManager
@@ -17,7 +19,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -45,23 +46,28 @@ class TodoConfiguration(
     @Bean
     fun redisCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
         val objectMapper = jacksonObjectMapper()
-        val pagedTodoSerializer = Jackson2JsonRedisSerializer(objectMapper, TodoPageServiceResponseDTO::class.java)
-        val todoSerializer = Jackson2JsonRedisSerializer(objectMapper, TodoServiceResponseDTO::class.java)
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .apply {
+                activateDefaultTyping(
+                    LaissezFaireSubTypeValidator.instance,
+                    ObjectMapper.DefaultTyping.NON_FINAL,
+                    JsonTypeInfo.As.PROPERTY
+                )
+            }
 
         val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .disableCachingNullValues()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer(objectMapper)
+                )
+            )
             .entryTtl(Duration.ofMinutes(1))
-
-        val pagedTodoConfig = defaultConfig.serializeValuesWith(
-            RedisSerializationContext.SerializationPair.fromSerializer(pagedTodoSerializer)
-        )
-        val todoConfig = defaultConfig.serializeValuesWith(
-            RedisSerializationContext.SerializationPair.fromSerializer(todoSerializer)
-        )
 
         return RedisCacheManager.builder(connectionFactory)
             .cacheDefaults(defaultConfig)
-            .withInitialCacheConfigurations(mapOf("todos" to pagedTodoConfig, "todo" to todoConfig))
             .build()
     }
 

--- a/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
+++ b/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.seokjoo.todo.common.common.jwt.JwtAuthFilter
 import com.seokjoo.todo.common.common.jwt.JwtProvider
 import com.seokjoo.todo.domain.service.todo.TodoPageServiceResponseDTO
+import com.seokjoo.todo.domain.service.todo.TodoServiceResponseDTO
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Bean
@@ -12,8 +14,12 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.Duration
@@ -39,15 +45,38 @@ class TodoConfiguration(
     @Bean
     fun redisCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
         val objectMapper = jacksonObjectMapper()
-        val serializer = Jackson2JsonRedisSerializer(objectMapper, TodoPageServiceResponseDTO::class.java)
+        val pagedTodoSerializer = Jackson2JsonRedisSerializer(objectMapper, TodoPageServiceResponseDTO::class.java)
+        val todoSerializer = Jackson2JsonRedisSerializer(objectMapper, TodoServiceResponseDTO::class.java)
 
-        val config = RedisCacheConfiguration.defaultCacheConfig()
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .disableCachingNullValues()
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
             .entryTtl(Duration.ofMinutes(1))
 
+        val pagedTodoConfig = defaultConfig.serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(pagedTodoSerializer)
+        )
+        val todoConfig = defaultConfig.serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(todoSerializer)
+        )
+
         return RedisCacheManager.builder(connectionFactory)
-            .cacheDefaults(config)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(mapOf("todos" to pagedTodoConfig, "todo" to todoConfig))
             .build()
+    }
+
+    @Bean
+    fun redisConnectionFactory(@Value("\${spring.data.redis.port:6379}") port: Int): RedisConnectionFactory {
+        val redisHost = "localhost"
+        return LettuceConnectionFactory(redisHost, port)
+    }
+
+    @Bean
+    fun redisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
+        return RedisTemplate<String, Any>().apply {
+            connectionFactory = redisConnectionFactory
+            keySerializer = StringRedisSerializer()
+            valueSerializer = GenericJackson2JsonRedisSerializer()
+        }
     }
 }

--- a/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
+++ b/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
@@ -44,7 +45,7 @@ class TodoConfiguration(
     }
 
     @Bean
-    fun redisCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+    fun todoCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
         val objectMapper = jacksonObjectMapper()
             .registerModule(JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
@@ -55,8 +56,8 @@ class TodoConfiguration(
                     JsonTypeInfo.As.PROPERTY
                 )
             }
-
-        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+        val defaultConfig = RedisCacheConfiguration
+            .defaultCacheConfig()
             .disableCachingNullValues()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
             .serializeValuesWith(
@@ -66,15 +67,19 @@ class TodoConfiguration(
             )
             .entryTtl(Duration.ofMinutes(1))
 
-        return RedisCacheManager.builder(connectionFactory)
+        return RedisCacheManager
+            .RedisCacheManagerBuilder
+            .fromConnectionFactory(connectionFactory)
             .cacheDefaults(defaultConfig)
             .build()
     }
 
     @Bean
-    fun redisConnectionFactory(@Value("\${spring.data.redis.port:6379}") port: Int): RedisConnectionFactory {
-        val redisHost = "localhost"
-        return LettuceConnectionFactory(redisHost, port)
+    fun redisConnectionFactory(
+        @Value("\${spring.data.redis.port:6379}") port: Int,
+        @Value("\${spring.data.redis.host:localhost}") redisHost: String,
+    ): RedisConnectionFactory {
+        return LettuceConnectionFactory(RedisStandaloneConfiguration(redisHost, port))
     }
 
     @Bean

--- a/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
+++ b/src/main/kotlin/com/seokjoo/todo/presentation/configuration/TodoConfiguration.kt
@@ -4,10 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.seokjoo.todo.common.common.jwt.JwtAuthFilter
 import com.seokjoo.todo.common.common.jwt.JwtProvider
 import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.Duration
 
 @Configuration
 class TodoConfiguration(
@@ -25,5 +32,21 @@ class TodoConfiguration(
             addUrlPatterns("/*")
             order = 1
         }
+    }
+
+    @Bean
+    fun redisCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+        val config = RedisCacheConfiguration.defaultCacheConfig()
+            .disableCachingNullValues()
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+            .entryTtl(Duration.ofMinutes(1)) // 임의의 1분
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(config)
+            .build()
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -24,6 +24,10 @@ spring:
   cache:
     type: redis
 
+logging:
+  level:
+    org.springframework.cache: trace
+
 jwt:
   secret: ${JWT_SECRETS}
   accessTokenExpiration: ${JWT_ACCESS_TOKEN_EXPIRED_TIME}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,6 +21,8 @@ spring:
       host: localhost:6379
       password: ${REDIS_PASSWORD}
       port: 6379
+  cache:
+    type: redis
 
 jwt:
   secret: ${JWT_SECRETS}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,7 +18,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
   data:
     redis:
-      host: localhost:6379
+      host: localhost
       password: ${REDIS_PASSWORD}
       port: 6379
   cache:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,6 +16,11 @@ spring:
       hibernate.format_sql: true
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
+  data:
+    redis:
+      host: localhost:6379
+      password: ${REDIS_PASSWORD}
+      port: 6379
 
 jwt:
   secret: ${JWT_SECRETS}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -14,6 +14,10 @@ spring:
     show-sql: true
     database: h2
     database-platform: org.hibernate.dialect.H2Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 jwt:
   secret: ${JWT_SECRETS}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -17,7 +17,9 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6379
+      port: 6380
+  cache:
+    type: redis
 
 jwt:
   secret: ${JWT_SECRETS}

--- a/src/test/kotlin/com/seokjoo/todo/TodoE2ETest.kt
+++ b/src/test/kotlin/com/seokjoo/todo/TodoE2ETest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -30,7 +31,9 @@ import java.time.format.DateTimeFormatter
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-class TodoE2ETest {
+class TodoE2ETest @Autowired constructor(
+    private val redisTemplate: RedisTemplate<String, Any>
+) {
 
     @LocalServerPort
     private val port: Int = 8080
@@ -54,6 +57,14 @@ class TodoE2ETest {
     fun beforeEach() {
         insertInitialData()
         addHeader()
+    }
+
+    @AfterEach
+    fun cleanupRedis() {
+        val todos = redisTemplate.keys("todos:*")
+        val todo = redisTemplate.keys("todo:*")
+        redisTemplate.delete(todos)
+        redisTemplate.delete(todo)
     }
 
     private fun insertInitialData() {

--- a/src/test/kotlin/com/seokjoo/todo/TodoE2ETest.kt
+++ b/src/test/kotlin/com/seokjoo/todo/TodoE2ETest.kt
@@ -32,7 +32,10 @@ import java.time.format.DateTimeFormatter
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 class TodoE2ETest @Autowired constructor(
-    private val redisTemplate: RedisTemplate<String, Any>
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val objectMapper: ObjectMapper,
+    private val jdbcTemplate: JdbcTemplate,
+    private val loginService: TodoAuthService,
 ) {
 
     @LocalServerPort
@@ -40,14 +43,6 @@ class TodoE2ETest @Autowired constructor(
 
     private val restTemplate: RestTemplate = RestTemplate()
 
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
-    @Autowired
-    private lateinit var jdbcTemplate: JdbcTemplate
-
-    @Autowired
-    private lateinit var loginService: TodoAuthService
     private lateinit var header: HttpHeaders
 
     /**

--- a/src/test/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceSpringBootTest.kt
+++ b/src/test/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceSpringBootTest.kt
@@ -7,15 +7,22 @@ import com.seokjoo.todo.domain.repository.categorytodo.TodoCategoryRepository
 import com.seokjoo.todo.presentation.todo.dto.request.TodoPageRequest
 import com.seokjoo.todo.presentation.todo.dto.request.toPageServiceDTO
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @IntegrationTest
 class TodoServiceSpringBootTest @Autowired constructor(
     private val service: TodoService,
     private val categoryRepository: CategoryRepository,
     private val todoCategoryRepository: TodoCategoryRepository,
+    private val redisTemplate: RedisTemplate<String, Any>,
 ) {
     lateinit var result: TodoServiceResponseDTO
 
@@ -24,6 +31,12 @@ class TodoServiceSpringBootTest @Autowired constructor(
         val request = TodoServiceRequestDTO(todo = "android", isDone = true, categoryNames = listOf("drama"))
         // when
         result = service.createTodo(request)
+    }
+
+    @AfterEach
+    fun cleanupRedis() {
+        val keys = redisTemplate.keys("todos:*")
+        redisTemplate.delete(keys)
     }
 
     // 통합 테스트

--- a/src/test/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceSpringBootTest.kt
+++ b/src/test/kotlin/com/seokjoo/todo/domain/service/todo/TodoServiceSpringBootTest.kt
@@ -11,11 +11,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
-import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @IntegrationTest
 class TodoServiceSpringBootTest @Autowired constructor(


### PR DESCRIPTION
redis를 이용해서 캐싱 추가했습니다

테스트용, 운영용 redis는 분리했습니다 (어차피 쓰고 지우면 같지만,,, 운영에 영향주기 싫어서요)

<img width="1585" alt="image" src="https://github.com/user-attachments/assets/f61d91a4-6d8f-4b8c-9a3a-c1a20e33c19c" />

근데, 5회 측정 (캐시 적용 전, 후 )을 비교하면 캐시 적용 후가 평균적으로 더 느린데요,
캐시 사용 전  : 301ms, 34ms, 38ms, 31ms, 25ms  -> 평균 : 85.8ms
캐시 사용 후  : 469ms, 29ms, 13ms, 15ms, 11 ms. -> 평균 : 107.4ms

캐시 사용후 처음은 redis에서 먼저 체크를 하고 이후에 db를 찔러서 느린 걸로 알고 있는데 (cache aside 때문에..),
캐시를 사용한 값들이랑 아닌 것들이랑 크게 속도차이가 없더라구요?! 

제 생각에는 1차 캐시에서 바로 값을 가져와서 속도가 빠른 것 같은데, 맞을까요????
=> 세션 단위로 작동해서 이건 아닌 것 같네요 , , , , 
=> 추가로 데이터 갯수가 너무 적어서 그런 것도 있는 것 같네욤

스쿼시 머지 꼭 하기...!!!
close #17 